### PR TITLE
Bmi f90

### DIFF
--- a/Tests/TestAllMethods_f90.F90
+++ b/Tests/TestAllMethods_f90.F90
@@ -835,12 +835,16 @@ subroutine TestAllMethods_f90()  BIND(C, NAME='TestAllMethods_f90')
 	return
 
   ! Deallocate
+  deallocate(IntVector, IntVector2)
+  deallocate(DoubleVector, DoubleVector2)
+  deallocate(StringVector, AllocString)
   deallocate(IntVector)
-  deallocate(DoubleVector)
+  deallocate(Names)
   deallocate(v1, v2, f1)
   deallocate(ic1, ic2)
-  deallocate(cells)
-  deallocate(bc1)
+  deallocate(u1, u2, ic)
+  deallocate(cells, v1, v2)
+  deallocate(bc1, c, bc_species, bc2)
   deallocate(tc)
   deallocate(p_atm)
   return

--- a/src/BMIPhreeqcRM.cpp
+++ b/src/BMIPhreeqcRM.cpp
@@ -501,7 +501,7 @@ std::string BMIPhreeqcRM::GetVarType(const std::string name)
 			}
 		}
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetVarType.");
 	return "Failed in GetVarType.";
 }
 std::string BMIPhreeqcRM::GetVarUnits(const std::string name)
@@ -528,7 +528,7 @@ std::string BMIPhreeqcRM::GetVarUnits(const std::string name)
 			return it->second.GetUnits();
 		}
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetVarUnits.");
 	return "Failed in GetVarUnits.";
 }
 
@@ -556,7 +556,7 @@ int BMIPhreeqcRM::GetVarItemsize(const std::string name)
 			return it->second.GetItemsize();
 		}
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetVarItemsize.");
 	return 0;
 }
 
@@ -584,7 +584,7 @@ int BMIPhreeqcRM::GetVarNbytes(const std::string name)
 			return it->second.GetNbytes();
 		}
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetVarNbytes.");
 	return 0;
 }
 double BMIPhreeqcRM::GetCurrentTime()
@@ -696,7 +696,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, void* dest)
 	std::ostringstream oss;
 	oss << "BMI GetValue void* failed for variable " << name << std::endl;
 	this->ErrorMessage(oss.str(), true);
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, bool& dest)
@@ -717,7 +717,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, bool& dest)
 		dest = this->var_man->VarExchange.GetBVar();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, bool* dest)
@@ -746,7 +746,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, bool* dest)
 	std::ostringstream oss;
 	oss << "BMI GetValue bool* failed for variable " << name << std::endl;
 	this->ErrorMessage(oss.str(), true);
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, double& dest)
@@ -767,7 +767,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, double& dest)
 		dest = this->var_man->VarExchange.GetDVar();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, double* dest)
@@ -823,7 +823,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, double* dest)
 	std::ostringstream oss;
 	oss << "BMI GetValue double* failed for variable " << name << std::endl;
 	this->ErrorMessage(oss.str(), true);
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, int& dest)
@@ -843,7 +843,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, int& dest)
 		dest = this->var_man->VarExchange.GetIVar();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, int* dest)
@@ -878,7 +878,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, int* dest)
 		this->ErrorMessage(oss.str(), true);
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, std::string& dest)
@@ -899,7 +899,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, std::string& dest)
 		dest = this->var_man->VarExchange.GetStringVar();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, std::vector<double>& dest)
@@ -942,7 +942,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, std::vector<double>& dest)
 			return;
 		}
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, std::vector<int>& dest)
@@ -962,7 +962,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, std::vector<int>& dest)
 		dest = this->var_man->VarExchange.GetIntVectorRef();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void BMIPhreeqcRM::GetValue(const std::string name, std::vector<std::string>& dest)
@@ -982,7 +982,7 @@ void BMIPhreeqcRM::GetValue(const std::string name, std::vector<std::string>& de
 		dest = this->var_man->VarExchange.GetStringVectorRef();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValue.");
 	return;
 }
 void* BMIPhreeqcRM::GetValuePtr(const std::string name)
@@ -999,7 +999,7 @@ void* BMIPhreeqcRM::GetValuePtr(const std::string name)
 		}
 		return bv.GetVoidPtr();
 	}
-	assert(false);
+	throw std::runtime_error("Failed in GetValuePtr.");
 	return NULL;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, void* src)
@@ -1071,7 +1071,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, void* src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, bool src)
@@ -1094,7 +1094,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, bool src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, const char* src)
@@ -1116,7 +1116,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, const char* src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, double src)
@@ -1138,7 +1138,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, double src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, int src)
@@ -1160,7 +1160,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, int src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, const std::string src)
@@ -1182,7 +1182,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, const std::string src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, std::vector<double> src)
@@ -1214,7 +1214,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, std::vector<double> src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, std::vector<int> src)
@@ -1239,7 +1239,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, std::vector<int> src)
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 void BMIPhreeqcRM::SetValue(const std::string name, std::vector<std::string> src)
@@ -1261,7 +1261,7 @@ void BMIPhreeqcRM::SetValue(const std::string name, std::vector<std::string> src
 		((*this->var_man).*bv.GetFn())();
 		return;
 	}
-	assert(false);
+	throw std::runtime_error("Failed in SetValue.");
 	return;
 }
 

--- a/src/VarManager.cpp
+++ b/src/VarManager.cpp
@@ -175,16 +175,16 @@ void VarManager::ComponentCount_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}	
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -241,16 +241,16 @@ void VarManager::Components_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -368,7 +368,7 @@ void VarManager::DensityCalculated_Var()
 	}
 	case VarManager::VAR_TASKS::SetVar:
 	{
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::no_op:
@@ -404,10 +404,7 @@ void VarManager::DensityUser_Var()
 		//this->PointerSet.insert(RMVARS::DensityUser);
 		//this->UpdateSet.insert(RMVARS::DensityUser);
 		//break;
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::RMUpdate:
@@ -417,13 +414,14 @@ void VarManager::DensityUser_Var()
 		//rm_ptr->GetConcentrations(c);
 		//BMIVariant& bv_c = this->VariantMap[RMVARS::Concentrations];
 		//bv_c.SetDoubleVector(c);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 	}
 	case VarManager::VAR_TASKS::GetVar:
 	case VarManager::VAR_TASKS::Update:
 	{
 		//rm_ptr->GetDensityUser(this->VarExchange.GetDoubleVectorRef());
 		//bv.SetDoubleVector(this->VarExchange.GetDoubleVectorRef());
-		assert(false);
+		throw std::runtime_error("GetValue not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
@@ -472,10 +470,7 @@ void VarManager::ErrorString_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -488,7 +483,7 @@ void VarManager::ErrorString_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::no_op:
 	case VarManager::VAR_TASKS::Info:
@@ -523,10 +518,7 @@ void VarManager::FilePrefix_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -590,7 +582,7 @@ void VarManager::Gfw_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::no_op:
 	case VarManager::VAR_TASKS::Info:
@@ -632,16 +624,16 @@ void VarManager::GridCellCount_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -670,18 +662,12 @@ void VarManager::NthSelectedOutput_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValue not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
@@ -693,7 +679,7 @@ void VarManager::NthSelectedOutput_Var()
 	case VarManager::VAR_TASKS::RMUpdate:
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -748,7 +734,7 @@ void VarManager::SaturationCalculated_Var()
 	}
 	case VarManager::VAR_TASKS::SetVar:
 	{
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::no_op:
@@ -778,16 +764,13 @@ void VarManager::SaturationUser_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("GetValue not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::RMUpdate:
@@ -849,10 +832,7 @@ void VarManager::SelectedOutput_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -863,10 +843,10 @@ void VarManager::SelectedOutput_Var()
 	}
 	case VarManager::VAR_TASKS::Update:
 	case VarManager::VAR_TASKS::RMUpdate:
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::no_op:
 	case VarManager::VAR_TASKS::Info:
@@ -895,10 +875,7 @@ void VarManager::SelectedOutputColumnCount_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -908,16 +885,16 @@ void VarManager::SelectedOutputColumnCount_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -946,10 +923,7 @@ void VarManager::SelectedOutputCount_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -959,16 +933,16 @@ void VarManager::SelectedOutputCount_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -1025,10 +999,7 @@ void VarManager::SelectedOutputHeadings_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -1051,16 +1022,16 @@ void VarManager::SelectedOutputHeadings_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -1090,10 +1061,7 @@ void VarManager::SelectedOutputRowCount_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -1103,16 +1071,16 @@ void VarManager::SelectedOutputRowCount_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -1160,7 +1128,7 @@ void VarManager::SolutionVolume_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::no_op:
 	case VarManager::VAR_TASKS::Info:
@@ -1281,10 +1249,7 @@ void VarManager::CurrentSelectedOutputUserNumber_Var()
 	{
 	case VarManager::VAR_TASKS::GetPtr:
 	{
-#if defined(WITH_PYBIND11)
-		throw std::runtime_error("This variable does not support get_value_ptr.");
-#endif
-		assert(false);
+		throw std::runtime_error("GetValuePtr not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::GetVar:
@@ -1294,16 +1259,16 @@ void VarManager::CurrentSelectedOutputUserNumber_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::RMUpdate:
 	{
-		assert(false);
+		throw std::runtime_error("RMUpdate not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Update:
 	{
-		assert(false);
+		throw std::runtime_error("Update not supported for this variable.");
 		break;
 	}
 	case VarManager::VAR_TASKS::Info:
@@ -1625,7 +1590,7 @@ void VarManager::Viscosity_Var()
 		break;
 	}
 	case VarManager::VAR_TASKS::SetVar:
-		assert(false);
+		throw std::runtime_error("SetValue not supported for this variable.");
 		break;
 	case VarManager::VAR_TASKS::no_op:
 	case VarManager::VAR_TASKS::Info:


### PR DESCRIPTION
Replaced asserts with unguarded throws. I used C++ method names in error messages, but throws will affect C++, F90, and Python. 