### PR TITLE
backward compatibility for density and saturation

### DIFF
--- a/src/PhreeqcRM.cpp
+++ b/src/PhreeqcRM.cpp
@@ -158,6 +158,7 @@ PhreeqcRM::PhreeqcRM(int nxyz_arg, MP_TYPE data_for_parallel_processing, PHRQ_io
 , mpi_worker_callback_c{ nullptr }
 , mpi_worker_callback_cookie{ nullptr }
 , species_save_on{ false }
+, worker_waiting{ false }
 // errors
 , error_count{ 0 }
 , error_handler_mode{ 0 }
@@ -3597,6 +3598,14 @@ PhreeqcRM::GetCurrentSelectedOutputUserNumber(void)
 }
 /* ---------------------------------------------------------------------- */
 IRM_RESULT
+PhreeqcRM::GetDensity(std::vector<double>& density_arg)
+/* ---------------------------------------------------------------------- */
+{
+	// For backward compatibility
+	return GetDensityCalculated(density_arg);
+}
+/* ---------------------------------------------------------------------- */
+IRM_RESULT
 PhreeqcRM::GetDensityCalculated(std::vector<double> & density_arg)
 /* ---------------------------------------------------------------------- */
 {
@@ -4369,6 +4378,14 @@ PhreeqcRM::GetPressure(void)
 }
 #endif
 
+/* ---------------------------------------------------------------------- */
+IRM_RESULT
+PhreeqcRM::GetSaturation(std::vector<double>& sat_arg)
+/* ---------------------------------------------------------------------- */
+{
+	// For backward compatibility
+	return GetSaturationCalculated(sat_arg);
+}
 /* ---------------------------------------------------------------------- */
 IRM_RESULT
 PhreeqcRM::GetSaturationCalculated(std::vector<double> & sat_arg)
@@ -11499,6 +11516,14 @@ PhreeqcRM::SetDatabaseFileName(const char * db)
 
 /* ---------------------------------------------------------------------- */
 IRM_RESULT
+PhreeqcRM::SetDensity(const std::vector<double>& t)
+/* ---------------------------------------------------------------------- */
+{
+	// For backward compatibility
+	return SetDensityUser(t);
+}
+/* ---------------------------------------------------------------------- */
+IRM_RESULT
 PhreeqcRM::SetDensityUser(const std::vector<double> &t)
 /* ---------------------------------------------------------------------- */
 {
@@ -12045,6 +12070,16 @@ PhreeqcRM::SetRepresentativeVolume(const std::vector<double> &t)
 	return this->ReturnHandler(result_value, "PhreeqcRM::" + methodName);
 }
 
+/* ---------------------------------------------------------------------- */
+IRM_RESULT
+PhreeqcRM::SetSaturation(const std::vector<double>& t)
+/* ---------------------------------------------------------------------- */
+{
+	// For backward compatibility
+	return SetSaturationUser(t);
+}
+
+/* ---------------------------------------------------------------------- */
 IRM_RESULT
 PhreeqcRM::SetSaturationUser(const std::vector<double> &t)
 /* ---------------------------------------------------------------------- */

--- a/src/PhreeqcRM.h
+++ b/src/PhreeqcRM.h
@@ -876,6 +876,7 @@ status = phreeqc_rm.GetDensityCalculated(density);
 Called by root, workers must be in the loop of @ref MpiWorker.
  */
 	IRM_RESULT                                GetDensityCalculated(std::vector< double > & d_output);
+	IRM_RESULT                                GetDensity(std::vector< double >& d_output);
 /**
 Returns a vector of integers that contains the largest reaction-cell number assigned to each worker.
 Each worker is assigned a range of reaction-cell numbers that are run during a call to @ref RunCells.
@@ -1875,6 +1876,7 @@ status = phreeqc_rm.GetSaturationCalculated(sat);
 Called by root, workers must be in the loop of @ref MpiWorker.
  */
 IRM_RESULT               GetSaturationCalculated(std::vector< double > & sat_output);
+IRM_RESULT               GetSaturation(std::vector< double >& sat_output);
 /**
 Returns the array of selected-output values for the current selected-output definition.
 @ref SetCurrentSelectedOutputUserNumber
@@ -4303,6 +4305,7 @@ phreeqc_rm.SetDensityUser(initial_density);
 Called by root, workers must be in the loop of @ref MpiWorker.
  */
 	IRM_RESULT                                SetDensityUser(const std::vector< double > &density);
+	IRM_RESULT                                SetDensity(const std::vector< double >& density);
 /**
 Set the name of the dump file. It is the name used by @ref DumpModule.
 @param dump_name        Name of dump file.
@@ -4999,6 +5002,7 @@ status = phreeqc_rm.SetSaturationUser(sat);
 Called by root, workers must be in the loop of @ref MpiWorker.
  */
 	IRM_RESULT                                SetSaturationUser(const std::vector< double > &sat);
+	IRM_RESULT                                SetSaturation(const std::vector< double >& sat);
 /**
 Set the property that controls whether messages are written to the screen.
 Messages include information about rebalancing during @ref RunCells, and

--- a/src/RM_interface.F90
+++ b/src/RM_interface.F90
@@ -1025,6 +1025,15 @@
     RM_GetDensityCalculated = RMF_GetDensityCalculated(id, density)
     return
     END FUNCTION RM_GetDensityCalculated
+    
+    INTEGER FUNCTION RM_GetDensity(id, density)
+    USE ISO_C_BINDING
+    IMPLICIT NONE
+    INTEGER, INTENT(in) :: id
+    real(kind=8), INTENT(inout), dimension(:), allocatable  :: density
+    RM_GetDensity = RM_GetDensityCalculated(id, density)
+    return
+    END FUNCTION RM_GetDensity
 
     !> Returns an array with the ending cell numbers from the range of cell numbers 
     !> assigned to each worker.
@@ -2384,6 +2393,14 @@
     rmf_errors = allocate_double_1d(sat_calc, rmf_nxyz)
     RM_GetSaturationCalculated = RMF_GetSaturationCalculated(id, sat_calc)
     END FUNCTION RM_GetSaturationCalculated
+    
+    INTEGER FUNCTION RM_GetSaturation(id, sat_calc)
+    USE ISO_C_BINDING
+    IMPLICIT NONE
+    INTEGER, INTENT(in) :: id
+    real(kind=8), INTENT(inout), DIMENSION(:), allocatable :: sat_calc
+    RM_GetSaturation = RM_GetSaturationCalculated(id, sat_calc)
+    END FUNCTION RM_GetSaturation
 
     !> Populates an array with values from the current selected-output definition. 
     !> @ref RM_SetCurrentSelectedOutputUserNumber or @ref RM_SetNthSelectedOutput determines 
@@ -5630,7 +5647,15 @@
     if (rmf_debug) call Chk_SetDensityUser(id, density)
     RM_SetDensityUser = RMF_SetDensityUser(id, density)
     END FUNCTION RM_SetDensityUser
-
+    
+    INTEGER FUNCTION RM_SetDensity(id, density)
+    USE ISO_C_BINDING
+    IMPLICIT NONE
+    INTEGER, INTENT(in) :: id
+    real(kind=8), DIMENSION(:), INTENT(in) :: density
+    RM_SetDensity = RM_SetDensityUser(id, density)
+    END FUNCTION RM_SetDensity
+    
     SUBROUTINE Chk_SetDensityUser(id, density)
     IMPLICIT NONE
     INTEGER, INTENT(in) :: id
@@ -6623,6 +6648,14 @@
     if (rmf_debug) call Chk_SetSaturationUser(id, sat)
     RM_SetSaturationUser = RMF_SetSaturationUser(id, sat)
     END FUNCTION RM_SetSaturationUser
+    
+    INTEGER FUNCTION RM_SetSaturation(id, sat)
+    USE ISO_C_BINDING
+    IMPLICIT NONE
+    INTEGER, INTENT(in) :: id
+    real(kind=8), DIMENSION(:), INTENT(in) :: sat
+    RM_SetSaturation = RM_SetSaturationUser(id, sat)
+    END FUNCTION RM_SetSaturation
 
     SUBROUTINE Chk_SetSaturationUser(id, sat)
     IMPLICIT NONE


### PR DESCRIPTION
Reimplemented GetDensity, SetDensity, GetSaturation, and SetSaturation as calls to GetDensityCalculated, SetDensityUser, GetSaturationCalculated, and SetSaturationUser to restore backward compatibility.